### PR TITLE
Make some internals public to allow creating a model from buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ fn is_legal_image(image: &ImageData) -> bool {
     image.num_channels() == 1 && image.width() > 0 && image.height() > 0
 }
 
-struct FuStDetector {
+pub struct FuStDetector {
     model: Model,
     wnd_data_buf: Vec<u8>,
     wnd_data: Vec<u8>,
@@ -137,7 +137,7 @@ struct FuStDetector {
 }
 
 impl FuStDetector {
-    fn new(model: Model) -> Self {
+    pub fn new(model: Model) -> Self {
         let wnd_size = 40;
         let slide_wnd_step_x = 4;
         let slide_wnd_step_y = 4;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -72,14 +72,14 @@ pub fn load_model(path: &str) -> Result<Model, io::Error> {
     ModelReader::new(buf).read()
 }
 
-struct ModelReader {
+pub struct ModelReader {
     reader: Cursor<Vec<u8>>,
     lab_boosted_feature_map: Rc<RefCell<LabBoostedFeatureMap>>,
     surf_mlp_feature_map: Rc<RefCell<SurfMlpFeatureMap>>,
 }
 
 impl ModelReader {
-    fn new(buf: Vec<u8>) -> Self {
+    pub fn new(buf: Vec<u8>) -> Self {
         ModelReader {
             reader: Cursor::new(buf),
             lab_boosted_feature_map: Rc::new(RefCell::new(LabBoostedFeatureMap::new())),


### PR DESCRIPTION
This opens up some more parts of the API, to allow creation of a model
from an in memory buffer instead of a file.

For example:

```rust
use rustface::{Detector, FuStDetector};
use rustface::model::ModelReader;

fn custom_make_detector(buf: Vec<u8>) -> Box<Detector> {
    let model = ModelReader::new(buf).read()?;
    Box::new(FuStDetector::new(model))
}
```