### PR TITLE
Add feature to make use of rayon optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ checksum = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 
 [[package]]
 name = "rayon"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
+checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,5 @@ harness = false
 [profile.release]
 lto = true
 
-
-features = ["rayon"]
-default=["rayon"]
-
+[features]
+default = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 num = "0.3"
 byteorder = "1.2.6"
-rayon = { version="1.0.2", optional=true }
+rayon = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
 image = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 num = "0.3"
 byteorder = "1.2.6"
-rayon = "1.0.2"
+rayon = { version="1.0.2", optional=true }
 
 [dev-dependencies]
 image = "0.23"
@@ -29,3 +29,8 @@ harness = false
 
 [profile.release]
 lto = true
+
+
+features = ["rayon"]
+default=["rayon"]
+

--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ export RAYON_NUM_THREADS=2
 cargo run --release --example image_demo model/seeta_fd_frontal_v1.0.bin <path-to-image>
 ```
 
+Note that Rayon can be disabled entirely at compile time by providing the `--no-default-features` flag.
+
 ## TODO
 
 * Use stable SIMD intrinsics when available
+* Benchmark benefit of parallelisation. Compiler improvements may have reduced the relative benefit of parallel processing, especially when running on smaller images. Simplify where possible.
 * Parallelize remaining CPU intensive loops
 * Tests (it would make sense to start with an integration test for `Detector::detect`, based on the results retrieved from the original library)
 

--- a/src/classifier/surf_mlp_classifier.rs
+++ b/src/classifier/surf_mlp_classifier.rs
@@ -167,30 +167,19 @@ struct Layer {
 }
 
 impl Layer {
-    #[cfg(feature = "rayon")]
     fn compute(&self, input: &[f32], output: &mut [f32]) {
-        self.weights
-            .par_chunks(self.input_dim)
-            .zip(&self.biases)
-            .zip(output)
-            .for_each(|((weights, bias), output)| {
-                let x =
-                    math::vector_inner_product(input.as_ptr(), weights.as_ptr(), self.input_dim)
-                        + bias;
-                *output = (self.act_func)(x);
-            });
-    }
+        #[cfg(feature = "rayon")]
+        let it = self.weights.par_chunks(self.input_dim);
 
-    #[cfg(not(feature = "rayon"))]
-    fn compute(&self, input: &[f32], output: &mut [f32]) {
-        self.weights
-            .chunks(self.input_dim)
+        #[cfg(not(feature = "rayon"))]
+        let it = self.weights.chunks(self.input_dim);
+
+        it
             .zip(&self.biases)
             .zip(output)
             .for_each(|((weights, bias), output)| {
-                let x =
-                    math::vector_inner_product(input.as_ptr(), weights.as_ptr(), self.input_dim)
-                        + bias;
+                let x = math::vector_inner_product(input.as_ptr(), weights.as_ptr(), self.input_dim)
+                    + bias;
                 *output = (self.act_func)(x);
             });
     }

--- a/src/feat/surf_mlp_featmap.rs
+++ b/src/feat/surf_mlp_featmap.rs
@@ -146,19 +146,18 @@ impl SurfMlpFeatureMap {
             let step = self.width as usize;
 
             #[cfg(feature = "rayon")]
-            self.img_buf
+            let it = self.img_buf
                 .par_chunks(step)
-                .zip(self.grad_y[step..].par_chunks_mut(step))
-                .for_each(|(inputs, outputs)| {
-                    let src = inputs.as_ptr();
-                    let dest = outputs.as_mut_ptr();
-                    math::vector_sub(src.offset((step << 1) as isize), src, dest, len);
-                });
+                .zip(self.grad_y[step..]
+                .par_chunks_mut(step));
 
             #[cfg(not(feature = "rayon"))]
-            self.img_buf
+            let it = self.img_buf
                 .chunks(step)
-                .zip(self.grad_y[step..].chunks_mut(step))
+                .zip(self.grad_y[step..]
+                .chunks_mut(step));
+
+            it
                 .for_each(|(inputs, outputs)| {
                     let src = inputs.as_ptr();
                     let dest = outputs.as_mut_ptr();


### PR DESCRIPTION
Wow this is really great work. I am super impressed with your library.

I want to use it in a project I am working on but I need to insure it doesn't use more than one core. I know its an odd use case :) .

I know I could set an ENV var to limit rayon to just one core, but that is really inconvenient. Here is a patch to allow a user to disable rayon if they want. I have enabled rayon as one of the default features since I would think more people would want it enabled. 