### PR TITLE
Use slices for image data

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -47,14 +47,14 @@ fn detect_single_image(c: &mut Criterion) {
 
     // convert to rustface internal image datastructure
     let (width, height) = img.dimensions();
-    let mut test_image = ImageData::new(img.as_ptr(), width, height);
 
     let target_runtime = Duration::new(100, 0);
 
     c.bench(
         "detect_single_image",
         Benchmark::new("detect", move |b| {
-            b.iter(|| detector.detect(&mut test_image))
+            let test_image = ImageData::new(&img, width, height);
+            b.iter(|| detector.detect(&test_image))
         })
         // Limit the measurement time and the sample size
         // to make sure the benchmark finishes in a feasible amount of time.

--- a/examples/image_demo.rs
+++ b/examples/image_demo.rs
@@ -75,7 +75,7 @@ fn main() {
 
 fn detect_faces(detector: &mut dyn Detector, gray: &GrayImage) -> Vec<FaceInfo> {
     let (width, height) = gray.dimensions();
-    let mut image = ImageData::new(gray.as_ptr(), width, height);
+    let mut image = ImageData::new(gray, width, height);
     let now = Instant::now();
     let faces = detector.detect(&mut image);
     println!(

--- a/src/detector/mod.rs
+++ b/src/detector/mod.rs
@@ -26,7 +26,7 @@ use crate::Detector;
 const FUST_MIN_WINDOW_SIZE: u32 = 20;
 
 impl Detector for FuStDetector {
-    fn detect(&mut self, image: &mut ImageData) -> Vec<FaceInfo> {
+    fn detect(&mut self, image: &ImageData) -> Vec<FaceInfo> {
         if !is_legal_image(image) {
             panic!("Illegal image: {:?}", image);
         }
@@ -162,7 +162,7 @@ impl FuStDetector {
             .resize((roi_width * roi_height) as usize, 0);
         let mut src;
         unsafe {
-            src = img.data().offset((roi.y() * img_width + roi.x()) as isize);
+            src = img.data().as_ptr().offset((roi.y() * img_width + roi.x()) as isize);
         }
         let mut dest = self.wnd_data_buf.as_mut_ptr();
         let len = roi_width as usize;
@@ -224,10 +224,10 @@ impl FuStDetector {
             }
         }
 
-        let src_img = ImageData::new(self.wnd_data_buf.as_ptr(), roi.width(), roi.height());
+        let src_img = ImageData::new(&self.wnd_data_buf, roi.width(), roi.height());
         resize_image(
             &src_img,
-            self.wnd_data.as_mut_ptr(),
+            &mut self.wnd_data,
             self.wnd_size,
             self.wnd_size,
         );
@@ -343,7 +343,7 @@ impl FuStDetector {
 
                             self.get_window_data(&image1x, bboxes[m].bbox_mut());
                             let img_temp = ImageData::new(
-                                self.wnd_data.as_ptr(),
+                                &self.wnd_data,
                                 self.wnd_size,
                                 self.wnd_size,
                             );

--- a/src/feat/lab_boosted_featmap.rs
+++ b/src/feat/lab_boosted_featmap.rs
@@ -39,7 +39,7 @@ pub struct LabBoostedFeatureMap {
 }
 
 impl FeatureMap for LabBoostedFeatureMap {
-    fn compute(&mut self, input: *const u8, width: u32, height: u32) {
+    fn compute(&mut self, input: &[u8], width: u32, height: u32) {
         if width == 0 || height == 0 {
             panic!(format!(
                 "Illegal arguments: width ({}), height ({})",
@@ -152,7 +152,7 @@ impl LabBoostedFeatureMap {
     fn reshape(&mut self, width: u32, height: u32) {
         self.width = width;
         self.height = height;
-        self.length = (width * height) as usize;
+        self.length = width as usize * height as usize;
 
         self.feat_map.resize(self.length, 0);
         self.rect_sum.resize(self.length, 0);
@@ -160,13 +160,12 @@ impl LabBoostedFeatureMap {
         self.square_int_img.resize(self.length, 0);
     }
 
-    fn compute_integral_images(&mut self, input: *const u8) {
+    fn compute_integral_images(&mut self, input: &[u8]) {
+        assert_eq!(input.len(), self.length);
+
         unsafe {
-            math::copy_u8_to_i32(input, self.int_img.as_mut_ptr(), self.length);
-            math::square(
-                &self.int_img[..self.length],
-                &mut self.square_int_img[..self.length],
-            );
+            math::copy_u8_to_i32(input, &mut self.int_img);
+            math::square(&self.int_img, &mut self.square_int_img);
 
             LabBoostedFeatureMap::compute_integral(
                 self.int_img.as_mut_ptr(),

--- a/src/feat/mod.rs
+++ b/src/feat/mod.rs
@@ -26,5 +26,5 @@ use crate::common::Rectangle;
 
 pub trait FeatureMap {
     fn set_roi(&mut self, roi: Rectangle);
-    fn compute(&mut self, input: *const u8, width: u32, height: u32);
+    fn compute(&mut self, input: &[u8], width: u32, height: u32);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub trait Detector {
     /// Panics if `image` is not a legal image, e.g. it
     /// - is not gray-scale (`num_channels` is not equal to 1)
     /// - has `width` or `height` equal to 0
-    fn detect(&mut self, image: &mut ImageData) -> Vec<FaceInfo>;
+    fn detect(&mut self, image: &ImageData) -> Vec<FaceInfo>;
 
     /// Set the size of the sliding window.
     ///

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -16,9 +16,11 @@
 // You should have received a copy of the BSD 2-Clause License along with the software.
 // If not, see < https://opensource.org/licenses/BSD-2-Clause>.
 
-pub unsafe fn copy_u8_to_i32(src: *const u8, dest: *mut i32, length: usize) {
-    for i in 0..length as isize {
-        *dest.offset(i) = i32::from(*src.offset(i));
+#[inline]
+pub fn copy_u8_to_i32(src: &[u8], dest: &mut [i32]) {
+    let dest = &mut dest[0..src.len()]; // eliminates a branch from the loop
+    for (value, dest) in src.iter().copied().zip(dest.iter_mut()) {
+        *dest = i32::from(value);
     }
 }
 


### PR DESCRIPTION
* Makes extend_from_slice manage img_buf's capacity, which avoids reallocations
* safe `copy_u8_to_i32` generates the same assembly for the inner loop
* ImageData can actually have a correct lifetime
