### PR TITLE
Make it possible to run ./test.sh from bin folder

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -9,7 +9,7 @@ fi
 
 if [[ ${RUSTFACE_HOME} == "" ]]
 then
-    export RUSTFACE_HOME=$PWD
+    export RUSTFACE_HOME=`dirname "$0"`/../
 fi
 echo "Using ${RUSTFACE_HOME} as the working directory"
 


### PR DESCRIPTION
If someone like me goes to bin folder and runs "./test.sh ../assets/test/scientists.jpg", file_not_found error will occur.
Fixed RUSTFACE_HOME detection when script runs from other places.